### PR TITLE
Fix broken video links in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1142,7 +1142,7 @@
                 <div class="relative w-full pt-[56.25%]">
                     <iframe
                         class="absolute inset-0 w-full h-full rounded-2xl"
-                        src="https://www.youtube.com/watch?v=K5gdsmmMgA8"
+                        src="https://www.youtube.com/embed/K5gdsmmMgA8"
                         title="TriChokro Pathfinder Team"
                         frameborder="0"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -1168,7 +1168,7 @@
                 <div class="relative w-full pt-[56.25%]">
                     <iframe
                         class="absolute inset-0 w-full h-full rounded-2xl"
-                        src="https://www.youtube.com/embed/7Uzam6XvLgY"
+                        src="https://www.youtube.com/embed/K5gdsmmMgA8"
                         title="UIHP Pitch Deck"
                         frameborder="0"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
Fixed broken video links in `index.html` to ensure they load correctly and align with the Bangla version (`index_bn.html`). Specifically, corrected a `watch?v=` URL to `embed/` and updated the third video ID.

---
*PR created automatically by Jules for task [2052912372875685047](https://jules.google.com/task/2052912372875685047) started by @wiki-ruhan*