### PR TITLE
Add video showcase to Trambulance pages

### DIFF
--- a/trambulance.html
+++ b/trambulance.html
@@ -247,6 +247,24 @@
             </div>
         </section>
 
+        <!-- Video Showcase Section -->
+        <section id="video-showcase" class="w-full bg-slate-950 py-10 border-b border-white/5 relative overflow-hidden">
+            <div class="max-w-6xl mx-auto px-4 relative z-10">
+                <div class="text-center mb-8">
+                    <h2 class="text-3xl md:text-4xl font-bold mb-2 text-white">360° View</h2>
+                    <p class="text-slate-400 text-sm uppercase tracking-widest">Experience the Design</p>
+                </div>
+                <div class="rounded-2xl overflow-hidden border border-purple-500/20 shadow-[0_0_50px_-10px_rgba(147,51,234,0.3)] relative group w-full max-w-4xl mx-auto">
+                     <video class="w-full h-auto object-cover" autoplay loop muted playsinline>
+                         <source src="src/assets/trambulance%20rotate.mp4" type="video/mp4">
+                         Your browser does not support the video tag.
+                     </video>
+                </div>
+            </div>
+            <!-- Background Glow -->
+            <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[60%] h-[60%] bg-purple-600/10 blur-[100px] rounded-full pointer-events-none"></div>
+        </section>
+
         <!-- Problem Section -->
         <section id="tramb-problem" class="py-24 bg-slate-900 relative">
             <div class="max-w-7xl mx-auto px-6">

--- a/trambulance_bn.html
+++ b/trambulance_bn.html
@@ -247,6 +247,24 @@
             </div>
         </section>
 
+        <!-- Video Showcase Section -->
+        <section id="video-showcase" class="w-full bg-slate-950 py-10 border-b border-white/5 relative overflow-hidden">
+            <div class="max-w-6xl mx-auto px-4 relative z-10">
+                <div class="text-center mb-8">
+                    <h2 class="text-3xl md:text-4xl font-bold mb-2 text-white">৩৬০° ভিউ</h2>
+                    <p class="text-slate-400 text-sm uppercase tracking-widest">ডিজাইনটি দেখুন</p>
+                </div>
+                <div class="rounded-2xl overflow-hidden border border-purple-500/20 shadow-[0_0_50px_-10px_rgba(147,51,234,0.3)] relative group w-full max-w-4xl mx-auto">
+                     <video class="w-full h-auto object-cover" autoplay loop muted playsinline>
+                         <source src="src/assets/trambulance%20rotate.mp4" type="video/mp4">
+                         Your browser does not support the video tag.
+                     </video>
+                </div>
+            </div>
+            <!-- Background Glow -->
+            <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[60%] h-[60%] bg-purple-600/10 blur-[100px] rounded-full pointer-events-none"></div>
+        </section>
+
         <!-- Problem Section -->
         <section id="tramb-problem" class="py-24 bg-slate-900 relative">
             <div class="max-w-7xl mx-auto px-6">


### PR DESCRIPTION
This change adds a video showcase section to the Trambulance product pages (English and Bengali). The video `trambulance rotate.mp4` is displayed in a styled container, configured to autoplay silently. This provides a 360-degree view of the design to visitors. Verified with Playwright screenshots.

---
*PR created automatically by Jules for task [3984648928437082255](https://jules.google.com/task/3984648928437082255) started by @wiki-ruhan*